### PR TITLE
Fix check_samplesheet.py

### DIFF
--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -260,7 +260,7 @@ class AssayChecker:
                     f"Cannot find probe_set specified [{probe_set}] under {probe_loc}"
                 )
         elif add_msg:
-            print_error(add_msg)
+            print_error(record_id, add_msg)
 
 
     def additional_checks(self, record_id, record):


### PR DESCRIPTION
In line 263, `print_error` is called without the correct number of arguments. This fix simply adds as input the `record_id`, one of the required arguments to `print_error`.