### PR TITLE
Add time to saturation module slurm scheduling

### DIFF
--- a/modules/saturation.nf
+++ b/modules/saturation.nf
@@ -9,6 +9,8 @@ process SEQUENCING_SATURATION {
     publishDir "${params.pubdir}/${record.output_id}/${record.tool}", pattern: "sequencing_saturation.csv", mode: "copy"
     label "high_mem"
 
+    time { (record.n_reads / 600000000).round(2) * 1.hour * params.time_scale_factor }
+
     container "library://singlecell/python:3.8"
 
     input:

--- a/nextflow.config
+++ b/nextflow.config
@@ -17,5 +17,5 @@ manifest {
     homePage = "https://github.com/TheJacksonLaboratory/nf-tenx"
     mainScript = "main.nf"
     nextflowVersion = "!>=20.10.0"
-    version = "0.7.10"
+    version = "0.7.11"
 }


### PR DESCRIPTION
Sequencing saturation module runs was using default maxwalltime of 14 days or 21 days depending on the cluster.