### PR TITLE
Update memory scaling in qc.nf  to accommodate for larger fastq files

### DIFF
--- a/modules/qc.nf
+++ b/modules/qc.nf
@@ -11,7 +11,7 @@ process FASTQC {
 
     time { (record.n_reads / 300000000).round(2) * 4.hour * params.time_scale_factor }
     cpus 16
-    memory "${ (record.n_reads / 50000000).round(0) * 4}GB"
+    memory "${ Math.min(params.max_memory,(record.n_reads / 50000000).round(0) * 4) }GB" # takes the smallest of the 2 between the max memory set in the config params versus the scaled memory calculation based on read counts
 
     container "library://singlecell/fastqc:0.11.9"
 

--- a/modules/qc.nf
+++ b/modules/qc.nf
@@ -14,7 +14,7 @@ process FASTQC {
 
     def mem_Int_extract( String max_mem ) {
         return max_mem.replaceAll("[^0-9]", "")}
-    memory "${ Math.min(mem_Int_extract(params.max_memory),(record.n_reads / 50000000).round(0) * 4) }GB" // takes the smallest of the 2 between the max memory set in the config params versus the scaled memory calculation based on read counts
+    memory "${ Math.min(${mem_Int_extract(params.max_memory)},(record.n_reads / 50000000).round(0) * 4) }GB" // takes the smallest of the 2 between the max memory set in the config params versus the scaled memory calculation based on read counts
 
     container "library://singlecell/fastqc:0.11.9"
 

--- a/modules/qc.nf
+++ b/modules/qc.nf
@@ -12,7 +12,7 @@ process FASTQC {
     time { (record.n_reads / 300000000).round(2) * 4.hour * params.time_scale_factor }
     cpus 16
 
-    def mem_extract = params.max_memory.toString.replaceAll("[^0-9]", "")
+    def mem_extract = params.max_memory.toString().replaceAll("[^0-9]", "")
     def int_max_mem = mem_extract.toInteger()
     memory "${ Math.min(int_max_mem,(record.n_reads / 50000000).round(0).toInteger() * 4) }GB" // takes the smallest of the 2 between the max memory set in the config params versus the scaled memory calculation based on read counts
 

--- a/modules/qc.nf
+++ b/modules/qc.nf
@@ -11,7 +11,10 @@ process FASTQC {
 
     time { (record.n_reads / 300000000).round(2) * 4.hour * params.time_scale_factor }
     cpus 16
-    memory "${ Math.min(params.max_memory,(record.n_reads / 50000000).round(0) * 4) }GB" // takes the smallest of the 2 between the max memory set in the config params versus the scaled memory calculation based on read counts
+    def mem_Int_extract( String max_mem ) {
+    return max_mem.replaceAll("[^0-9]", "")
+    }
+    memory "${ Math.min(mem_Int_extract(params.max_memory),(record.n_reads / 50000000).round(0) * 4) }GB" // takes the smallest of the 2 between the max memory set in the config params versus the scaled memory calculation based on read counts
 
     container "library://singlecell/fastqc:0.11.9"
 

--- a/modules/qc.nf
+++ b/modules/qc.nf
@@ -11,10 +11,8 @@ process FASTQC {
 
     time { (record.n_reads / 300000000).round(2) * 4.hour * params.time_scale_factor }
     cpus 16
-
-    def mem_extract = params.max_memory.toString().replaceAll("[^0-9]", "")
-    def int_max_mem = mem_extract.toInteger()
-    memory "${ Math.min(int_max_mem,(record.n_reads / 50000000).round(0).toInteger() * 4) }GB" // takes the smallest of the 2 between the max memory set in the config params versus the scaled memory calculation based on read counts
+   
+    memory "${ Math.min(params.max_memory.toGiga(),(record.n_reads / 50000000).round(0).toInteger() * 4) }GB" // takes the smallest of the 2 between the max memory set in the config params versus the scaled memory calculation based on read counts
 
     container "library://singlecell/fastqc:0.11.9"
 

--- a/modules/qc.nf
+++ b/modules/qc.nf
@@ -12,9 +12,9 @@ process FASTQC {
     time { (record.n_reads / 300000000).round(2) * 4.hour * params.time_scale_factor }
     cpus 16
 
-    mem_extract = params.max_memory.replaceAll("[^0-9]", "")
-    int_max_mem = mem_extract.toInteger()
-    memory "${ Math.min(int_max_mem,(record.n_reads / 50000000).round(0) * 4) }GB" // takes the smallest of the 2 between the max memory set in the config params versus the scaled memory calculation based on read counts
+    def mem_extract = params.max_memory.toString.replaceAll("[^0-9]", "")
+    def int_max_mem = mem_extract.toInteger()
+    memory "${ Math.min(int_max_mem,(record.n_reads / 50000000).round(0).toInteger() * 4) }GB" // takes the smallest of the 2 between the max memory set in the config params versus the scaled memory calculation based on read counts
 
     container "library://singlecell/fastqc:0.11.9"
 

--- a/modules/qc.nf
+++ b/modules/qc.nf
@@ -11,7 +11,7 @@ process FASTQC {
 
     time { (record.n_reads / 300000000).round(2) * 4.hour * params.time_scale_factor }
     cpus 16
-    memory "${ Math.min(params.max_memory,(record.n_reads / 50000000).round(0) * 4) }GB" # takes the smallest of the 2 between the max memory set in the config params versus the scaled memory calculation based on read counts
+    memory "${ Math.min(params.max_memory,(record.n_reads / 50000000).round(0) * 4) }GB" // takes the smallest of the 2 between the max memory set in the config params versus the scaled memory calculation based on read counts
 
     container "library://singlecell/fastqc:0.11.9"
 

--- a/modules/qc.nf
+++ b/modules/qc.nf
@@ -12,8 +12,9 @@ process FASTQC {
     time { (record.n_reads / 300000000).round(2) * 4.hour * params.time_scale_factor }
     cpus 16
 
-    mem_Int_extract = params.max_memory.replaceAll("[^0-9]", "")
-    memory "${ Math.min(mem_Int_extract,(record.n_reads / 50000000).round(0) * 4) }GB" // takes the smallest of the 2 between the max memory set in the config params versus the scaled memory calculation based on read counts
+    mem_extract = params.max_memory.replaceAll("[^0-9]", "")
+    int_max_mem = mem_extract.toInteger()
+    memory "${ Math.min(int_max_mem,(record.n_reads / 50000000).round(0) * 4) }GB" // takes the smallest of the 2 between the max memory set in the config params versus the scaled memory calculation based on read counts
 
     container "library://singlecell/fastqc:0.11.9"
 

--- a/modules/qc.nf
+++ b/modules/qc.nf
@@ -12,9 +12,8 @@ process FASTQC {
     time { (record.n_reads / 300000000).round(2) * 4.hour * params.time_scale_factor }
     cpus 16
 
-    def mem_Int_extract( String max_mem ) {
-        return max_mem.replaceAll("[^0-9]", "")}
-    memory "${ Math.min(${mem_Int_extract(params.max_memory)},(record.n_reads / 50000000).round(0) * 4) }GB" // takes the smallest of the 2 between the max memory set in the config params versus the scaled memory calculation based on read counts
+    mem_Int_extract = params.max_memory.replaceAll("[^0-9]", "")
+    memory "${ Math.min(mem_Int_extract,(record.n_reads / 50000000).round(0) * 4) }GB" // takes the smallest of the 2 between the max memory set in the config params versus the scaled memory calculation based on read counts
 
     container "library://singlecell/fastqc:0.11.9"
 

--- a/modules/qc.nf
+++ b/modules/qc.nf
@@ -11,9 +11,9 @@ process FASTQC {
 
     time { (record.n_reads / 300000000).round(2) * 4.hour * params.time_scale_factor }
     cpus 16
+
     def mem_Int_extract( String max_mem ) {
-    return max_mem.replaceAll("[^0-9]", "")
-    }
+        return max_mem.replaceAll("[^0-9]", "")}
     memory "${ Math.min(mem_Int_extract(params.max_memory),(record.n_reads / 50000000).round(0) * 4) }GB" // takes the smallest of the 2 between the max memory set in the config params versus the scaled memory calculation based on read counts
 
     container "library://singlecell/fastqc:0.11.9"


### PR DESCRIPTION
Update memory scaling in qc.nf to take either max memory in config params or the memory scaling calculation, whichever is the smallest.