### PR TITLE
Call cellranger versions from module env instead of containers

### DIFF
--- a/modules/cellranger_gex.nf
+++ b/modules/cellranger_gex.nf
@@ -101,7 +101,7 @@ process CELLRANGER_COUNT {
     tag "$record.output_id"
     label "tenx_genomics_count"
 
-    container "library://singlecell/${record.tool}:${record.tool_version}"
+    module "/sc/service/tools/modules/10x-genomics/${record.tool}:${record.tool_version}"
 
     // cpus determined by profile
     // memory determined by profile


### PR DESCRIPTION
processes from module file will be edited to call cellranger versions from module instead of a singularity container