### PR TITLE
Fix fastq gathering when library names are substrings of other library names.

### DIFF
--- a/modules/samplesheet.nf
+++ b/modules/samplesheet.nf
@@ -31,7 +31,7 @@ def collect_fastqs(LinkedHashMap record) {
       for(lane in lanes) {
         file(fqp).eachFile {
 
-          fastq -> if(fastq =~ /${lib}.*L${lane}.*fastq.*/) {
+          fastq -> if(fastq =~ /${lib}_.*_L${lane}_.*fastq.*/) {
             if (fastq.isHidden()) { return }
             if (!(fastq in fastqs)) { fastqs.add(fastq.toString()) }
 


### PR DESCRIPTION
Fixed the problem where if a library ID of interest happens to be a strict substring of another (e.g. `L1` is a substring of `L12`), then both with be grabbed given the regex on line 34.