### PR TITLE
Use module in IMAGE_PROCESS in spaceranger.nf

### DIFF
--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -126,7 +126,8 @@ process IMAGE_PROCESS {
     tag "$record.output_id"
     label "tenx_genomics_count"
 
-    container "library://singlecell/${record.tool}:${record.tool_version}"
+    module { "${record.tool}/${record.tool_version}" }
+    ///container "library://singlecell/${record.tool}:${record.tool_version}"
 
     input:
       val(record)


### PR DESCRIPTION
IMAGE_PROCESS was still calling the singularity container instead of using module load to call spaceranger versions