### PR TITLE
Update cellranger_arc.nf to add --create-bam and --disable-cell-annotation as options for v2.1+

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "nextflow.telemetry.enabled": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "nextflow.telemetry.enabled": true
-}

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -97,7 +97,7 @@ class AssayChecker:
             SampleSheetField("tags"),
             SampleSheetField("no_bam"),
             SampleSheetField("disable_cell_annotation"),
-            SampleSheetFiled("create_bam")
+            SampleSheetField("create_bam")
         }
 
     def check_mutually_exclusive_fields(self, record_id, record, keys1, keys2):

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -84,7 +84,9 @@ class AssayChecker:
             "design",
             "probe_set", 
             "tags", 
-            "no_bam", 
+            "no_bam",
+            "create_bam",
+            "disable_cell_annotations"
         }
 
     def check_mutually_exclusive_fields(self, record_id, record, keys1, keys2):

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -6,7 +6,7 @@ import logging
 import argparse
 from pathlib import Path
 from string import ascii_letters
-from dataclasses import dataclass, field as dcfield
+from dataclasses import dataclass, field as dcfield, asdict
 
 import yaml
 from yaml import load, dump

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -6,6 +6,7 @@ import logging
 import argparse
 from pathlib import Path
 from string import ascii_letters
+from dataclasses import dataclass, field as dcfield
 
 import yaml
 from yaml import load, dump
@@ -41,6 +42,14 @@ def print_error(record_id, error, context="Line", context_str=""):
     sys.exit(1)
 
 
+@dataclass(frozen=True)
+class SampleSheetField:
+    key: str
+    on_filesystem: bool = dcfield(default=False)
+    required: bool = dcfield(default=False)
+    disallowed: bool = dcfield(default=False)
+    is_list: bool = dcfield(default=False)
+
 class AssayChecker:
     supported_tools = {
         "cellranger": ["count", "vdj", "multi", "aggr"],
@@ -66,27 +75,27 @@ class AssayChecker:
 
         self.allowed_library_types = library_types
 
-        self.required_fields = {
-            "libraries",
-            "library_types",
-            "fastq_paths",
-            "tool",
-            "tool_version",
-            "command",
-            "sample_name",
-            "reference_path",
-        }
-
-        self.allowed_fields = {
-            "use_undetermined", "lanes",
-            "n_cells", 
-            "is_nuclei", 
-            "design",
-            "probe_set", 
-            "tags", 
-            "no_bam",
-            "create_bam",
-            "disable_cell_annotations"
+        # A field's `required` flag captures whether it must be present; optional
+        # fields are simply those with required=False. Each field still carries its
+        # own on_filesystem/is_list metadata, validated uniformly in check().
+        self.fields = {
+            SampleSheetField("libraries", required=True, is_list=True),
+            SampleSheetField("library_types", required=True, is_list=True),
+            SampleSheetField("fastq_paths", required=True, on_filesystem=True, is_list=True),
+            SampleSheetField("tool", required=True),
+            SampleSheetField("tool_version", required=True),
+            SampleSheetField("command", required=True),
+            SampleSheetField("sample_name", required=True),
+            SampleSheetField("reference_path", required=True, on_filesystem=True),
+            SampleSheetField("use_undetermined"),
+            SampleSheetField("lanes"),
+            SampleSheetField("n_cells"),
+            SampleSheetField("is_nuclei"),
+            SampleSheetField("design"),
+            SampleSheetField("probe_set"),  # path relative to assets, checked separately
+            SampleSheetField("tags"),
+            SampleSheetField("no_bam"),
+            SampleSheetField("disable_cell_annotation")
         }
 
     def check_mutually_exclusive_fields(self, record_id, record, keys1, keys2):

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -96,7 +96,8 @@ class AssayChecker:
             SampleSheetField("probe_set"),  # path relative to assets, checked separately
             SampleSheetField("tags"),
             SampleSheetField("no_bam"),
-            SampleSheetField("disable_cell_annotation")
+            SampleSheetField("disable_cell_annotation"),
+            SampleSheetFiled("create_bam")
         }
 
     def check_mutually_exclusive_fields(self, record_id, record, keys1, keys2):

--- a/modules/cellranger_arc.nf
+++ b/modules/cellranger_arc.nf
@@ -13,6 +13,16 @@ def construct_arc_cli_options(record) {
     options["--reference"] = record.reference_path
     options["--libraries"] = "${record.output_id}.csv"
     options["--description"] = record.sample_name
+
+    #if (record.disable-cell-annotation) { options["--disable-cell-annotation"] = null }
+
+    versionParts = record.tool_version.tokenize('.')
+    major_version = record.tool_version[0].toInteger()
+    minor_version = record.tool_version[1].toInteger()
+
+    if ((record.no_bam) && (major_version <= 2) && (minor_version < 1)) { options["--no-bam"] = null }
+    if ((major_version >= 2) && (minor_version >= 1)) { options["--create-bam"] = record.create-bam ? true : false }
+
     return(join_map_items(options))
 }
 

--- a/modules/cellranger_arc.nf
+++ b/modules/cellranger_arc.nf
@@ -4,57 +4,93 @@ vim: syntax=groovy
 -*- mode: groovy;-*-
 */
 
-include { construct_library_csv_content; join_map_items } from './functions.nf'
- 
+include { construct_library_csv_content ; join_map_items } from './functions.nf'
+
 
 def construct_arc_cli_options(record) {
-    options = [:]
-    options["--id"] = record.output_id
-    options["--reference"] = record.reference_path
-    options["--libraries"] = "${record.output_id}.csv"
-    options["--description"] = record.sample_name
+  options = [:]
+  options["--id"] = record.output_id
+  options["--reference"] = record.reference_path
+  options["--libraries"] = "${record.output_id}.csv"
+  options["--description"] = record.sample_name
 
-    if (record.disable-cell-annotation) { options["--disable-cell-annotation"] = null }
+  [record.disable_cell_annotation, record.create_bam, record.no_bam].each { ele ->
+    if (ele == null) {
+      return null
+    }
 
-    versionParts = record.tool_version.tokenize('.')
-    major_version = record.tool_version[0].toInteger()
-    minor_version = record.tool_version[1].toInteger()
+    if (ele !instanceof Boolean) {
+      throw new Exception("`disable_cell_annotation`, `create_bam`, and `no_bam` must all be boolean values")
+    }
+  }
 
-    if ((record.no_bam) && (major_version <= 2) && (minor_version < 1)) { options["--no-bam"] = null }
-    if ((major_version >= 2) && (minor_version >= 1)) { options["--create-bam"] = record.create-bam ? true : false }
 
-    return(join_map_items(options))
+  // Define a separate variable just so we get nice editor completions
+  def version_parts = record.tool_version.tokenize(".")
+  def major_version = version_parts[0].toInteger()
+  def minor_version = version_parts[1].toInteger()
+
+  // the option --disable-cell-annotation is only available for cellranger-arc >= 2.2
+  def version_is_ge_2_2 = major_version >= 2 && minor_version >= 2
+
+  // Note that we explicitly check that disable_cell_annotation != null instead of a truthiness check
+  if (!version_is_ge_2_2 && record.disable_cell_annotation != null) {
+    throw new Exception("the option 'disable_cell_annotation' is only available for cellranger-arc >= 2.2")
+  }
+
+  if (record.disable_cell_annotation) {
+    options["--disable-cell-annotation"] = ""
+  }
+
+  def version_is_ge_2_1 = major_version >= 2 && minor_version >= 1
+  if (!version_is_ge_2_1 && record.create_bam != null) {
+    throw new Exception("the option 'create_bam' is oly available for cellranger-arc >= 2.1")
+  }
+
+  if (record.create_bam) {
+    options["--create-bam"] = ""
+  }
+
+  if (version_is_ge_2_1 && record.no_bam != null) {
+    throw new Exception("the option 'no_bam' is only available for cellranger-arc < 2.1")
+  }
+
+  if (record.no_bam) {
+    options["--no-bam"] = ""
+  }
+
+  return (join_map_items(options))
 }
 
 
 process CELLRANGER_ARC_COUNT {
-    publishDir "${params.pubdir}/${record.output_id}", pattern: "${record.tool_pubdir}/*", mode: "copy"
-    tag "$record.output_id"
-    label "tenx_genomics_count"
+  publishDir "${params.pubdir}/${record.output_id}", pattern: "${record.tool_pubdir}/*", mode: "copy"
+  tag "${record.output_id}"
+  label "tenx_genomics_count"
 
-    // cpus determined by profile
-    // memory determined by profile
-    // n_reads here counts both ATAC + GEX, so scale down the factor here.
-    time { (record.n_reads / 300000000).round(2) * 6.hour * params.time_scale_factor }
-    module { "${record.tool}/${record.tool_version}" }
-    //container "library://singlecell/${record.tool}:${record.tool_version}"
+  // cpus determined by profile
+  // memory determined by profile
+  // n_reads here counts both ATAC + GEX, so scale down the factor here.
+  time { (record.n_reads / 300000000).round(2) * 6.hour * params.time_scale_factor }
+  module { "${record.tool}/${record.tool_version}" }
 
-    input:
-      val record
-    output:
-      tuple val(record), path("${record.tool_pubdir}/*"), emit: cellranger_arc_outputs
-      tuple val(record), path("${record.tool_pubdir}/*"), emit: hash_dir
-      tuple val(record), path("${record.tool_pubdir}/*{metrics,summary}*", glob: true), emit: metrics
+  input:
+  val record
 
-    script:
-    main_options = construct_arc_cli_options(record)
-    lib_csv_content = construct_library_csv_content(record)
-    localmem = Math.round(task.memory.toGiga() * 0.95)
-    """
+  output:
+  tuple val(record), path("${record.tool_pubdir}/*"), emit: cellranger_arc_outputs
+  tuple val(record), path("${record.tool_pubdir}/*"), emit: hash_dir
+  tuple val(record), path("${record.tool_pubdir}/*{metrics,summary}*", glob: true), emit: metrics
+
+  script:
+  main_options = construct_arc_cli_options(record)
+  lib_csv_content = construct_library_csv_content(record)
+  localmem = Math.round(task.memory.toGiga() * 0.95)
+  """
     lib_csv_file=${record.output_id}.csv
-    echo -e '$lib_csv_content' > \$lib_csv_file
+    echo -e '${lib_csv_content}' > \$lib_csv_file
 
-    cellranger-arc count $main_options --localcores=$task.cpus --localmem=$localmem
+    cellranger-arc count ${main_options} --localcores=${task.cpus} --localmem=${localmem}
 
     # do rearrange here
     mkdir -p ${record.tool_pubdir}/_files

--- a/modules/cellranger_arc.nf
+++ b/modules/cellranger_arc.nf
@@ -14,7 +14,7 @@ def construct_arc_cli_options(record) {
     options["--libraries"] = "${record.output_id}.csv"
     options["--description"] = record.sample_name
 
-    #if (record.disable-cell-annotation) { options["--disable-cell-annotation"] = null }
+    //if (record.disable-cell-annotation) { options["--disable-cell-annotation"] = null }
 
     versionParts = record.tool_version.tokenize('.')
     major_version = record.tool_version[0].toInteger()

--- a/modules/cellranger_arc.nf
+++ b/modules/cellranger_arc.nf
@@ -48,7 +48,7 @@ def construct_arc_cli_options(record) {
   }
 
   if (record.create_bam) {
-    options["--create-bam"] = ""
+    options["--create-bam"] = "true"
   }
 
   if (version_is_ge_2_1 && record.no_bam != null) {

--- a/modules/cellranger_arc.nf
+++ b/modules/cellranger_arc.nf
@@ -47,8 +47,9 @@ def construct_arc_cli_options(record) {
     throw new Exception("the option 'create_bam' is oly available for cellranger-arc >= 2.1")
   }
 
-  if (record.create_bam) {
-    options["--create-bam"] = "true"
+  // Again, check explicitly for null. cellranger requires an explicit true or false to be passed, so it's not like the other boolean flags you can give it
+  if (record.create_bam != null) {
+    options["--create-bam"] = record.create_bam
   }
 
   if (version_is_ge_2_1 && record.no_bam != null) {

--- a/modules/cellranger_arc.nf
+++ b/modules/cellranger_arc.nf
@@ -14,7 +14,7 @@ def construct_arc_cli_options(record) {
     options["--libraries"] = "${record.output_id}.csv"
     options["--description"] = record.sample_name
 
-    //if (record.disable-cell-annotation) { options["--disable-cell-annotation"] = null }
+    if (record.disable-cell-annotation) { options["--disable-cell-annotation"] = null }
 
     versionParts = record.tool_version.tokenize('.')
     major_version = record.tool_version[0].toInteger()


### PR DESCRIPTION
This chunk should parse major and minor versions of cr-arc to use --no-bam for v1.0 to v2.0 if listed in the record,  while using --create-bam as a required Boolean option for v2.1+.